### PR TITLE
Bump kerl to 2.2.1

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -1,4 +1,4 @@
-KERL_VERSION="2.2.0"
+KERL_VERSION="2.2.1"
 
 handle_failure() {
   function=$1


### PR DESCRIPTION
kerl 2.2.1 fixes a problem, where `openssl@3` is selected as default 
ssl library (because `brew --prefix openssl` points to it) which isn't yet supported by OTP.

The new kerl release pins the version to `openssl@1.1`.

This fixes #222 