### PR TITLE
Update Debian 13 dependency installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ If you want to install all the above:
 To install the whole dependency suite:
 `apt-get -y install build-essential autoconf m4 libncurses-dev libwxgtk3.2-dev libwxgtk-webview3.2-dev libgl1-mesa-dev libglu1-mesa-dev libpng-dev libssh-dev unixodbc-dev xsltproc fop libxml2-utils openjdk-17-jdk`
 
+#### Debian 13 (trixie)
+
+To install the whole dependency suite:
+`apt-get -y install build-essential autoconf m4 libncurses-dev libwxgtk3.2-dev libwxgtk-webview3.2-dev libgl1-mesa-dev libglu1-mesa-dev libpng-dev libssh-dev unixodbc-dev xsltproc fop libxml2-utils openjdk-21-jdk`
+
 ### Arch Linux
 
 Provides most of the needed build tools.


### PR DESCRIPTION
Updated the dependency installation instructions for Debian 13 to include openjdk-21.